### PR TITLE
feat(bridge/send): accept attachments for multimodal messages

### DIFF
--- a/data-machine-chat-bridge.php
+++ b/data-machine-chat-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: Data Machine Chat Bridge
  * Plugin URI: https://github.com/Extra-Chill/data-machine-chat-bridge
  * Description: External chat bridge connections for Data Machine. Message queue, webhook delivery, and REST API for any chat client integration.
- * Version: 0.3.1
+ * Version: 0.4.0
  * Requires at least: 6.9
  * Requires PHP: 8.2
  * Requires Plugins: data-machine
@@ -18,7 +18,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'DATAMACHINE_CHAT_BRIDGE_VERSION', '0.3.1' );
+define( 'DATAMACHINE_CHAT_BRIDGE_VERSION', '0.4.0' );
 define( 'DATAMACHINE_CHAT_BRIDGE_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DATAMACHINE_CHAT_BRIDGE_URL', plugin_dir_url( __FILE__ ) );
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.0] - 2026-04-20
+
+### Added
+- accept `attachments` array on `POST /bridge/send` (mirrors `/chat` schema) so bridge clients can forward multimodal messages. Pass-through to `datamachine/send-message` ability; no core changes required.
+
 ## [0.3.1] - 2026-04-03
 
 ### Fixed

--- a/inc/Api/BridgeEndpoints.php
+++ b/inc/Api/BridgeEndpoints.php
@@ -151,6 +151,21 @@ class BridgeEndpoints {
 						'description'       => 'Existing session ID to continue. Omit to create or reuse a session.',
 						'sanitize_callback' => 'sanitize_text_field',
 					),
+					'attachments' => array(
+						'type'              => 'array',
+						'required'          => false,
+						'description'       => 'Media attachments for multi-modal messages. Each item: {url, media_id, mime_type, filename}. Mirrors the /datamachine/v1/chat schema.',
+						'items'             => array(
+							'type'       => 'object',
+							'properties' => array(
+								'url'       => array( 'type' => 'string' ),
+								'media_id'  => array( 'type' => 'integer' ),
+								'mime_type' => array( 'type' => 'string' ),
+								'filename'  => array( 'type' => 'string' ),
+							),
+						),
+						'sanitize_callback' => array( self::class, 'sanitize_attachments' ),
+					),
 					'bridge_app' => array(
 						'type'              => 'string',
 						'required'          => false,
@@ -563,6 +578,11 @@ class BridgeEndpoints {
 			$input['session_id'] = $session_id;
 		}
 
+		$attachments = $request->get_param( 'attachments' );
+		if ( ! empty( $attachments ) && is_array( $attachments ) ) {
+			$input['attachments'] = $attachments;
+		}
+
 		$result = $ability->execute( $input );
 
 		if ( is_wp_error( $result ) ) {
@@ -679,5 +699,60 @@ class BridgeEndpoints {
 		}
 
 		return self::normalize_string_list( $message_ids );
+	}
+
+	/**
+	 * Sanitize the attachments array from a /bridge/send request.
+	 *
+	 * Mirrors DataMachine\Api\Chat\Chat::sanitize_attachments() shape so the
+	 * payload handed to datamachine/send-message is identical regardless of
+	 * which entry point (REST /chat or /bridge/send) produced it.
+	 *
+	 * Each item is accepted as an array with any of {url, media_id, mime_type,
+	 * filename}. Items missing BOTH url and media_id are dropped so the
+	 * orchestrator never receives empty attachments.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param mixed $attachments Raw attachments from the request.
+	 * @return array Sanitized attachments list.
+	 */
+	public static function sanitize_attachments( $attachments ): array {
+		if ( ! is_array( $attachments ) ) {
+			return array();
+		}
+
+		$sanitized = array();
+
+		foreach ( $attachments as $attachment ) {
+			if ( ! is_array( $attachment ) ) {
+				continue;
+			}
+
+			$item = array();
+
+			if ( ! empty( $attachment['url'] ) ) {
+				$item['url'] = esc_url_raw( $attachment['url'] );
+			}
+
+			if ( ! empty( $attachment['media_id'] ) ) {
+				$item['media_id'] = absint( $attachment['media_id'] );
+			}
+
+			if ( ! empty( $attachment['mime_type'] ) ) {
+				$item['mime_type'] = sanitize_mime_type( $attachment['mime_type'] );
+			}
+
+			if ( ! empty( $attachment['filename'] ) ) {
+				$item['filename'] = sanitize_file_name( $attachment['filename'] );
+			}
+
+			// Must have at least a URL or media_id — otherwise the orchestrator has nothing to ingest.
+			if ( ! empty( $item['url'] ) || ! empty( $item['media_id'] ) ) {
+				$sanitized[] = $item;
+			}
+		}
+
+		return $sanitized;
 	}
 }


### PR DESCRIPTION
Closes #7

## Summary
- Adds `attachments` param to `POST /datamachine/v1/bridge/send`, matching the `/datamachine/v1/chat` schema: `[{url, media_id, mime_type, filename}]`
- New `BridgeEndpoints::sanitize_attachments()` mirrors `Chat::sanitize_attachments()` — items missing both `url` and `media_id` are dropped
- `handle_send()` passes attachments straight to `datamachine/send-message` (ability already accepts them)

## Why
Unblocks the image→Instagram flow: Beeper → Matrix → `mautrix-data-machine` → `/bridge/send` → chat multimodal → `publish_instagram` tool. DM core and `data-machine-socials` already support everything downstream; this was the missing link.

## Key detail: no `resolve_attachment_paths()` needed

`ConversationManager::buildMultiModalContent()` (core) explicitly handles URL-only attachments via `{ type: 'image_url', image_url: { url } }` when `file_path` isn't present (see `ConversationManager.php` line 100-104). The Matrix bot uploads images to WP Media first and hands the bridge a public `source_url` — orchestrator is happy.

## Contract
Text-only calls unchanged (`attachments` is optional). The only existing caller is the Go mautrix bot (Extra-Chill/mautrix-data-machine#11) which starts sending the new field after its own PR lands.

## Files
- `inc/Api/BridgeEndpoints.php` — schema + sanitize method + handle_send wiring
- `data-machine-chat-bridge.php` — version bump to 0.4.0
- `docs/CHANGELOG.md` — entry added

## Follow-up
- Extra-Chill/mautrix-data-machine#11 — Go side that produces image attachments
- Instagram OAuth needs to be connected in DM settings (separate one-off admin task)